### PR TITLE
Editted import_data command, added email backend to settings for savi…

### DIFF
--- a/api_yamdb/api/views.py
+++ b/api_yamdb/api/views.py
@@ -11,7 +11,7 @@ from rest_framework_simplejwt.tokens import RefreshToken
 
 from .filters import TitleFilters
 from .mixins import CreateListDestroyViewSet
-from .permissions import IsAdmin, IsGuest
+from .permissions import IsAdmin, IsAdminOrReadOnly, IsGuest
 from .serializers import (AdminSerializer, CategorySerializer,
                           CommentSerializer, GenreSerializer, ReviewSerializer,
                           SignupSerializer, TitleGETSerializer,
@@ -25,6 +25,7 @@ class TitleViewSet(viewsets.ModelViewSet):
     http_method_names = ['get', 'post', 'patch', 'delete']
     filter_backends = (DjangoFilterBackend,)
     filterset_class = TitleFilters
+    permission_classes = (IsAdminOrReadOnly,)
 
     def get_serializer_class(self):
         if self.request.method == 'GET':
@@ -37,11 +38,13 @@ class TitleViewSet(viewsets.ModelViewSet):
 class CategoryViewSet(CreateListDestroyViewSet):
     queryset = Category.objects.all()
     serializer_class = CategorySerializer
+    permission_classes = (IsAdminOrReadOnly,)
 
 
 class GenreViewSet(CreateListDestroyViewSet):
     queryset = Genre.objects.all()
     serializer_class = GenreSerializer
+    permission_classes = (IsAdminOrReadOnly,)
 
 
 class ReviewViewSet(viewsets.ModelViewSet):

--- a/api_yamdb/api_yamdb/settings.py
+++ b/api_yamdb/api_yamdb/settings.py
@@ -81,6 +81,9 @@ AUTH_PASSWORD_VALIDATORS = [
 
 AUTH_USER_MODEL = 'users.User'
 
+EMAIL_BACKEND = 'django.core.mail.backends.filebased.EmailBackend'
+EMAIL_FILE_PATH = BASE_DIR / 'sent_emails'
+
 
 REST_FRAMEWORK = {
     'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.PageNumberPagination',

--- a/api_yamdb/reviews/management/commands/import_data.py
+++ b/api_yamdb/reviews/management/commands/import_data.py
@@ -1,6 +1,6 @@
 import csv
 
-from django.db import IntegrityError
+from django.db import IntegrityError, OperationalError
 from django.core.management.base import BaseCommand, CommandError
 
 from reviews.models import (Category, Comment, Genre, Review, Title,
@@ -62,8 +62,12 @@ class Command(BaseCommand):
 
                     try:
                         model_name.objects.create(**row)
+
+                    except OperationalError as e:
+                        raise CommandError(e)
+
                     except IntegrityError:
                         continue
 
         self.stdout.write(self.style.SUCCESS(
-            'Данные успешно импортированы!'))
+            '\nДанные успешно импортированы!'))

--- a/api_yamdb/sent_emails/.gitignore
+++ b/api_yamdb/sent_emails/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/api_yamdb/users/apps.py
+++ b/api_yamdb/users/apps.py
@@ -2,4 +2,5 @@ from django.apps import AppConfig
 
 
 class UsersConfig(AppConfig):
+    default_auto_field = 'django.db.models.AutoField'
     name = 'users'


### PR DESCRIPTION
1. Немного изменил команду import_data, чтобы красиво выводила ошибку в случае отсутствия таблиц для импорта.
2. Добавил permission_classes к Category, Genre, Title.
3. Добавил в settings настройку email_backends, чтобы отправленные письма сохранялись в папке sent_emails (папка также создана и добавлена в git таким образом, чтобы файлы в ней в репозиторий не попадали, а сама папка оставалась).
4. Добавил в users/apps.py default_auto_field, чтобы убрать из консоли постоянно появляющийся жёлтый HINT от django.